### PR TITLE
docs: clarify civilians rule 15: VDM

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,4 +256,3 @@ _Last updated by Jim on 2025-03-30_
 3. Contract prices must be between $15k–$3M.
 4. Must follow NLR.
 5. No crimes outside contracts.
-


### PR DESCRIPTION
Changed:
- Rule 15 from "VEHICLES = ARMED" to VDM attempts = armed. 

Removed:
- **:** removed from `No compensation if` to fall in line with document. 